### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,11 +2,10 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    # Trigger when chart version tags are pushed
+    tags:
+      - '*'
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- run chart release on tag pushes instead of every push to main
- allow manual workflow dispatch

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840bfd30e4c832cbc2dde5b45ba2ca7